### PR TITLE
Update SpawnableEnv.cs

### DIFF
--- a/com.joebooth.many-worlds/Runtime/SpawnableEnv.cs
+++ b/com.joebooth.many-worlds/Runtime/SpawnableEnv.cs
@@ -25,6 +25,18 @@ namespace ManyWorlds
         Scene _spawnedScene;
         PhysicsScene _spawnedPhysicsScene;
 
+        void OnEnable()
+        {
+            foreach (Transform child in transform) {
+                child.gameObject.SetActive(true);
+
+
+            }
+        }
+
+
+
+
         private void FixedUpdate()
         {
             if (UseManyWorlds)


### PR DESCRIPTION
When the environment is spawned, its sons are activated. This is necessary for full compatibility with the procedural generation of the training environment, and has no impact on traditional training.